### PR TITLE
Handle phlex rails 2.x

### DIFF
--- a/app/views/rails_devtools/routes/route_details/controller_card.rb
+++ b/app/views/rails_devtools/routes/route_details/controller_card.rb
@@ -19,10 +19,7 @@ module RailsDevtools
       def view_template
         div(class: card_class) do
           div(class: "card-body") do
-            div(class: [
-                  "text-base flex justify-between gap-4 items-center",
-                  error? && "text-error"
-                ]) do
+            div(class: text_class) do
               div(class: "flex items-center ") do
                 if error?
                   span(class: "mr-1") do
@@ -52,6 +49,13 @@ module RailsDevtools
       end
 
       private
+
+      def text_class
+        [
+          "text-base flex justify-between gap-4 items-center",
+          error? && "text-error"
+        ].compact.join(" ")
+      end
 
       def card_class
         [

--- a/lib/rails_devtools/version.rb
+++ b/lib/rails_devtools/version.rb
@@ -1,3 +1,3 @@
 module RailsDevtools
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end

--- a/lib/rails_devtools/version.rb
+++ b/lib/rails_devtools/version.rb
@@ -1,3 +1,3 @@
 module RailsDevtools
-  VERSION = "0.2.0"
+  VERSION = "0.1.2"
 end

--- a/rails_devtools.gemspec
+++ b/rails_devtools.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.name = "rails_devtools"
   spec.version = RailsDevtools::VERSION
   spec.licenses = ["MIT"]
-  spec.required_ruby_version = ">= 3.3.1"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.authors = ["Maxime Souillat"]
   spec.email = ["maxime@beaucouplus.com"]

--- a/rails_devtools.gemspec
+++ b/rails_devtools.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.name = "rails_devtools"
   spec.version = RailsDevtools::VERSION
   spec.licenses = ["MIT"]
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 3.3.1"
 
   spec.authors = ["Maxime Souillat"]
   spec.email = ["maxime@beaucouplus.com"]
@@ -23,8 +23,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "fastimage", "~> 2.3", ">= 2.3.1"
-  spec.add_dependency "phlex", "~> 1.11", ">= 1.11.0"
-  spec.add_dependency "phlex-rails", "~> 1.1", ">= 1.1.2"
+  spec.add_dependency "phlex-rails", ">= 1.1.2", "< 3"
   spec.add_dependency "rails", ">= 7.1"
   spec.add_dependency "turbo-rails", "~> 2.0"
   spec.add_dependency "zeitwerk", "~> 2.6", ">= 2.6.12"


### PR DESCRIPTION
- Handle phlex rails 2.x
- Updated minimum ruby version to 3.3.1 (released in january 2024)

Fixes #1 